### PR TITLE
Update README

### DIFF
--- a/docker/README
+++ b/docker/README
@@ -37,3 +37,10 @@ cd hyp
 # itself is being built.
 
 make
+
+# Make qemu-for-android.
+
+make android-qemu
+
+# If this make fails due to permission issues, re-run the docker image
+# with additional parameters '--cap-add=SYS_ADMIN --privileged=true'.


### PR DESCRIPTION
Added a note about running docker with SYS_ADMIN caps if 'make android-qemu' fails due to permission denied.