### PR TITLE
Hyp-drv test kernel driver updates for Sep 2021.

### DIFF
--- a/core/smccall.c
+++ b/core/smccall.c
@@ -24,6 +24,9 @@ unsigned int smccall(register_t cn, register_t a1, register_t a2, register_t a3,
 	case PSCI_CPU_ON_SMC64:
 		psci_reg(cn, a1, a2, a3, a4, a5);
 		break;
+	case 0xFFFFFFFE:
+		LOG("Identity query...\n");
+		return 0x99;
 	default:
 		break;
 	}

--- a/driver/hyp-drv.h
+++ b/driver/hyp-drv.h
@@ -41,6 +41,6 @@ struct log_frag {
 #define HYPDRV_PAGE_VDSO	(_XN(0UL, 1UL)|_SH(1UL, 1UL)|_S2AP(1UL, 1UL))
 #define HYPDRV_PAGE_KERNEL_RO	(_XN(1UL, 0UL)|_SH(1UL, 1UL)|_S2AP(0UL, 1UL))
 
-#define s2_wb	(0xF << 2)        /* Outer & inner Write-Back Cacheable */
+#define s2_wb (0xF << 2)	/* Outer & inner Write-Back Cacheable */
 
 #endif // __HYP_DRV__


### PR DESCRIPTION
Check addresses for page alignment / align on page boundary.

Lock hvc call interface after installing memory mappings.

Signed-off-by: Konsta Karsisto <konsta.karsisto@gmail.com>