### PR TITLE
core: spinlock bugfixes and updates

### DIFF
--- a/core/guest.c
+++ b/core/guest.c
@@ -27,7 +27,7 @@
 #include "mbedtls/platform.h"
 
 extern struct mbedtls_entropy_context mbedtls_entropy_ctx;
-extern uint64_t core_lock;
+extern spinlock_t core_lock;
 
 #define CHECKRES(x) if (x != MBEDTLS_EXIT_SUCCESS) return -EFAULT;
 #define ARMV8_PMU_USERENR_MASK 0xf

--- a/core/hvccall.c
+++ b/core/hvccall.c
@@ -40,9 +40,9 @@ extern uint64_t __kvm_host_data[PLATFORM_CORE_COUNT];
 hyp_func_t *__fpsimd_guest_restore;
 extern uint64_t hyp_text_start;
 extern uint64_t hyp_text_end;
-extern uint64_t core_lock;
 extern bool at_debugstop;
-uint64_t crash_lock;
+extern spinlock_t core_lock;
+spinlock_t crash_lock;
 uint64_t hostflags;
 
 int set_lockflags(uint64_t flags, uint64_t addr, size_t sz, uint64_t depth)

--- a/core/kjump.c
+++ b/core/kjump.c
@@ -14,7 +14,7 @@
 
 static uint64_t kvm_jump_vector[MAX_KVM_JUMPS];
 static uint32_t jump_count;
-static uint64_t jump_lock;
+static spinlock_t jump_lock;
 
 static int compfunc(const void *v1, const void *v2)
 {

--- a/core/main.c
+++ b/core/main.c
@@ -30,7 +30,7 @@ struct timeval tv1 ALIGN(16);
 struct timeval tv2 ALIGN(16);
 uint8_t init_index;
 
-extern uint64_t entrylock;
+extern spinlock_t entrylock;
 extern uint64_t __stack[];
 extern uint64_t __fdt_addr;
 extern uint64_t __lr_addr;

--- a/core/spinlock.S
+++ b/core/spinlock.S
@@ -1,26 +1,26 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 .global spin_lock
 .type spin_lock, %function
+.align 2
 spin_lock:
 	sub	sp, sp, #(8 * 4)
-	str	x1, [sp, #(8 * 2)]
-	str	x2, [sp, #(8 * 3)]
+	stp	x1, x2, [sp, #(8 * 2)]
+	mrs	x1, mpidr_el1
 1:	ldxr	x2, [x0]
 	cbz	x2, 2f
 	wfe
 	b	1b
-2:	mov	x1, 1
-	stxr	w2, x1, [x0]
+2:	stxr	w2, x1, [x0]
 	cbz	w2, 3f
 	b	1b
 3:	dmb	sy
-	ldr	x1, [sp, #(8 * 2)]
-	ldr	x2, [sp, #(8 * 3)]
+	ldp	x1, x2, [sp, #(8 * 2)]
 	add	sp, sp, #(8 * 4)
 	ret
 
 .global spin_unlock
 .type spin_unlock, %function
+.align 2
 spin_unlock:
 	sub	sp, sp, #(8 * 4)
 	str	x1, [sp, #(8 * 2)]

--- a/core/spinlock.h
+++ b/core/spinlock.h
@@ -2,7 +2,13 @@
 #ifndef __SPINLOCK_H__
 #define __SPINLOCK_H__
 
-extern void spin_lock(void *lock);
-extern void spin_unlock(void *lock);
+#include <stdint.h>
+
+#include "helpers.h"
+
+typedef uint64_t spinlock_t ALIGN(8);
+
+extern void spin_lock(spinlock_t *lock);
+extern void spin_unlock(spinlock_t *lock);
 
 #endif // __SPINLOCK_H__

--- a/core/validate.c
+++ b/core/validate.c
@@ -10,7 +10,7 @@
 #include "tables.h"
 
 bool at_debugstop = false;
-extern uint64_t core_lock;
+extern spinlock_t core_lock;
 
 int debugstop(void)
 {

--- a/stdlib/putchar.c
+++ b/stdlib/putchar.c
@@ -54,7 +54,7 @@ struct _IO_FILE *stderr = &outstream;
 int _IO_putc(int c, struct _IO_FILE *__fp);
 
 #ifndef DEBUG
-static uint64_t print_lock;
+static spinlock_t print_lock;
 
 static void wraparound_ptrs(struct _IO_FILE *__fp)
 {


### PR DESCRIPTION
- force lock(s) to be properly aligned
- mark each lock with the owning cpu
- add tiny instruction optimizations

Signed-off-by: Janne Karhunen <Janne.Karhunen@gmail.com>