### PR TITLE
core: add memslot delete support

### DIFF
--- a/core/guest.h
+++ b/core/guest.h
@@ -115,7 +115,6 @@ struct kvm_guest {
 	kvm_page_data hyp_page_data[MAX_PAGING_BLOCKS];
 	uint64_t pd_index;
 	uint64_t ramend;
-	uint32_t sn;
 	uint8_t table_levels_el2s1;
 	uint8_t table_levels_el1s1;
 	uint8_t table_levels_el1s2;


### PR DESCRIPTION
Change the used slot index to follow KVM slot id.
Delete the slot (with given id) if slot is updated with
page count set to zero.

Signed-off-by: Jani Hyvonen <jani.hyvonen@digital14.com>