### PR TITLE
Use ssh keys for connecting to host vm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     stages {
-        
         stage('Clone project and build docker image') {
             agent any
             steps {
@@ -15,8 +14,6 @@ pipeline {
                 }
             }
         }
-        
-
         stage('Run make in container'){
             agent {
                 docker {
@@ -54,44 +51,51 @@ pipeline {
             steps {
                 sh 'cd /hyp && make KERNEL_DIR=/hyp/oss/linux GRAPHICS=1 run > /hyp/host.log &'
                 sh 'sleep 240'
-                
+
                 sh 'echo HOST_IP=$(grep ssh /hyp/host.log | cut -d" " -f7|cut -d":" -f1) > host_ips.sh'
                 sh 'cat host_ips.sh'
                 sh '''
                     source host_ips.sh
                     echo \$HOST_IP
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "sudo rm -rf /var/lib/apport/coredump/*"
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "sudo rm -rf /home/ubuntu/vm/browser"
-                    sshpass -p ubuntu scp -P 10022 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no linux-5.10.108/arch/arm64/boot/Image ubuntu@172.17.0.2:~/vm/ubuntu20
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "cd vm/ubuntu20 && ulimit -c unlimited && sudo ./run-qemu6-linux.sh > guest.log" &
+                    echo setting up ssh keys for host VM
+                    rm -f hostkey*
+                    mkdir -p ~/.ssh
+                    ssh-keygen -b 2048 -t rsa -f hostkey -q -N ""
+                    ssh-keyscan -p 10022 \$HOST_IP >> ~/.ssh/known_hosts
+                    sshpass -p ubuntu ssh-copy-id -i hostkey -p 10022 ubuntu@\$HOST_IP
+
+                    ssh -i hostkey ubuntu@\$HOST_IP -p 10022 "sudo rm -rf /var/lib/apport/coredump/*"
+                    scp -P 10022 -i hostkey linux-5.10.108/arch/arm64/boot/Image ubuntu@\$HOST_IP:~/vm/ubuntu20
+                    ssh -i hostkey ubuntu@\$HOST_IP -p 10022 "cd vm/ubuntu20 && ulimit -c unlimited && sudo ./run-qemu6-linux.sh > guest.log" &
                     echo $?
                 '''
 
                 sh 'sleep 480'
                 sh '''
                     source host_ips.sh
-                    
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "cat vm/ubuntu20/guest.log" >/hyp/guest.log
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "dmesg" >/hyp/host-dmesg.log
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "sudo chmod 444 /var/lib/apport/coredump/* || true"
+
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 "cat vm/ubuntu20/guest.log" >/hyp/guest.log
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 "dmesg" >/hyp/host-dmesg.log
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 "sudo chmod 444 /var/lib/apport/coredump/* || true"
                     sshpass -p ubuntu scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P10022 ubuntu@$HOST_IP:/var/lib/apport/coredump/* /hyp || true
                 '''
-                
+
                 sh 'echo GUEST1_IP=$(grep ssh /hyp/guest.log | cut -d" " -f7|cut -d":" -f1) >> host_ips.sh'
                 sh '''
                     source host_ips.sh
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 ssh ubuntu@$GUEST1_IP -p 2000 "dmesg" > /hyp/guest1-dmesg.log || true
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 ssh ubuntu@$GUEST1_IP -p 2000 "sudo shutdown now" || true
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 ssh ubuntu@$GUEST1_IP -p 2000 "dmesg" > /hyp/guest1-dmesg.log || true
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 ssh ubuntu@$GUEST1_IP -p 2000 "ps aux" > /hyp/guest1-ps.log || true
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 ssh ubuntu@$GUEST1_IP -p 2000 "sudo shutdown now" || true
                 '''
                 sh 'sleep 30'
                 sh '''
                     source host_ips.sh
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "ps aux"
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "sudo shutdown now" || true
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 "ps aux"
+                    ssh -i ./hostkey ubuntu@\$HOST_IP -p 10022 "sudo shutdown now" || true
                 '''
                 sh 'sleep 30'
             }
-        
+
             post {
                 always {
                     archiveArtifacts artifacts: '*.log', followSymlinks: false, allowEmptyArchive: true
@@ -101,14 +105,14 @@ pipeline {
                     script {
                         if (env.GITHUB_PR_SOURCE_BRANCH) {
                                 githubPRComment comment: githubPRMessage("[build passed: ${BUILD_NUMBER}](${BUILD_URL})."), statusVerifier: allowRunOnStatus("SUCCESS"), errorHandler: statusOnPublisherError("UNSTABLE")
-                        }                        
+                        }
                     }
                 }
                 failure{
                     script {
                         if (env.GITHUB_PR_SOURCE_BRANCH) {
                                 githubPRComment comment: githubPRMessage("[build failed: ${BUILD_NUMBER}](${BUILD_URL})."), statusVerifier: allowRunOnStatus("FAILURE"), errorHandler: statusOnPublisherError("UNSTABLE")
-                        }                        
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Generate ssh keys and use them for ssh connection with vm.
Keys are generated to avoid github complains about committed
keys.

This can be improved by not generating keys every time.