### PR TITLE
core: fix missing extern

### DIFF
--- a/core/hvccall.c
+++ b/core/hvccall.c
@@ -41,12 +41,12 @@ typedef int kvm_func_t(uint64_t, ...);
 
 extern struct hyp_extension_ops eops;
 extern uint64_t __kvm_host_data[PLATFORM_CORE_COUNT];
-hyp_func_t *__fpsimd_guest_restore;
 extern uint64_t hyp_text_start;
 extern uint64_t hyp_text_end;
 bool at_debugstop = false;
 extern spinlock_t core_lock;
 
+hyp_func_t *__fpsimd_guest_restore;
 spinlock_t crash_lock;
 
 int is_apicall(uint64_t cn)

--- a/platform/nxp/common/hyp_entrypoint.S
+++ b/platform/nxp/common/hyp_entrypoint.S
@@ -33,12 +33,6 @@ hyp_entrypoint:
 1:	bl	main
 
 .data
-.global __fpsimd_guest_restore
-.align	8
-__fpsimd_guest_restore:
-	.quad   0x000000000000
-
-.data
 .global entrylock
 .align	8
 entrylock:


### PR DESCRIPTION
add __fpsimd_guest_restore declaration to virt environment

Signed-off-by: Jouni Ukkonen <jouni.ukkonen@unikie.com>