### PR TITLE
CI: Check if kernel need to be updated to tested VMs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
                     echo \$HOST_IP
                     sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "sudo systemctl stop unattended-upgrades"
                     sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "sudo rm -rf /var/lib/apport/coredump/*"
-                    sshpass -p ubuntu scp -P 10022 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no linux-5.10.108/arch/arm64/boot/Image ubuntu@172.17.0.2:~/vm/ubuntu20
+                    sshpass -p ubuntu scp -P 10022 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no linux-$KERNEL_VERSION/arch/arm64/boot/Image ubuntu@172.17.0.2:~/vm/ubuntu20
                     sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "cd vm/ubuntu20 && ulimit -c unlimited && sudo ./run-qemu6-linux.sh > guest.log" &
                     echo $?
                 '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent none
     environment {
         // Kernel version for Ubuntu VMs
-        KERNEL_VERSION='5.10.108'
+        KERNEL_VERSION='5.10.130'
         // Path to Ubuntu host VM image
         IMAGE_FILE='/img/ubuntu20-host.qcow2'
         // Location of guest patch file in kvms project

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,11 +74,11 @@ pipeline {
                 sh 'cat host_ips.sh'
                 sh '''
                     source host_ips.sh
-                    echo \$HOST_IP
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "sudo systemctl stop unattended-upgrades"
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "sudo rm -rf /var/lib/apport/coredump/*"
-                    sshpass -p ubuntu scp -P 10022 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no linux-$KERNEL_VERSION/arch/arm64/boot/Image ubuntu@172.17.0.2:~/vm/ubuntu20
-                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "cd vm/ubuntu20 && ulimit -c unlimited && sudo ./run-qemu6-linux.sh > guest.log" &
+                    echo $HOST_IP
+                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "sudo systemctl stop unattended-upgrades"
+                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "sudo rm -rf /var/lib/apport/coredump/*"
+                    sshpass -p ubuntu scp -P 10022 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no linux-$KERNEL_VERSION/arch/arm64/boot/Image ubuntu@$HOST_IP:~/vm/ubuntu20
+                    sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "cd vm/ubuntu20 && ulimit -c unlimited && sudo ./run-qemu6-linux.sh > guest.log" &
                     echo $?
                 '''
 
@@ -88,7 +88,7 @@ pipeline {
                     echo "giving a lot of time for guest VM to start"
                     sleep 480
                     sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "cat vm/ubuntu20/guest.log"
-                    timeout 240s grep -q "Network is Online" <(sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "tail -f vm/ubuntu20/guest.log") || true
+                    timeout 240s grep -q "Network is Online" <(sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@$HOST_IP -p 10022 "tail -f vm/ubuntu20/guest.log") || true
                     sshpass -p ubuntu ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@\$HOST_IP -p 10022 "cat vm/ubuntu20/guest.log" >>/hyp/guest_nw.log
                     sleep 60
                 '''

--- a/scripts/ci-check-kernel-patch.sh
+++ b/scripts/ci-check-kernel-patch.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Script used to compare kernel version and patch used in previous CI build.
+# If a new kernel version or patch is used in CI build, scripts/update_kernel_to_ubuntu_VMs.sh will be executed.
+# The script will also remove the previous directory where kernel was updated (linux-<kernel version>) from workspace,
+# if a new kernel version is used in the current CI build.
+
+# Variables
+
+PRE_PATCH_DIR=previous_kernel
+PRE_PATCH_INFO=info
+
+# Functions
+
+usage() {
+  echo "$0 -i <VM image> -k <kernel version> -p <patch file> [ -d <info directory> -f <info file name> ]"
+  echo ""
+  echo "Example:"
+  echo "  $0 -i /img/ubuntu20-host.qcow2 -k 5.10.130 -p patches/guest/0001-kvm-encrypted-memory-draft-for-arm64-development.patch"
+  echo ""
+  echo "  Compares given kernel version and patch to ones used in previous CI build. If new version or patch is used in the build,"
+  echo "  builds patched kernel, installs modules to VMs and copies the resulting Image to current workspace."
+  echo "  After succesful kernel update, patch file will be stored to the info directory"
+  echo "  and info file inside it will be updated with the used kernel version and the stored patch file path."
+  echo "  If a new kernel version is used, the old dir with patched kernel sources (linux-<kernel version>) will be also removed."
+  echo ""
+  echo "  default info directory: $PRE_PATCH_DIR (can be overwritten by option -d)."
+  echo "  default info file name: $PRE_PATCH_INFO (can be overwritten by option -f)."
+}
+
+update_kernel() {
+  sudo modprobe nbd max_part=8
+  sudo scripts/update_kernel_to_ubuntu_VMs.sh -i $IMAGE_FILE -k $KERNEL_VERSION -p $PATCH_FILE
+  RV=$?
+  # storing kernel version / patch information for next build
+  if [ "$RV" -eq 0 ]; then
+    mkdir -p $PRE_PATCH_DIR
+    echo PRE_KERNEL_VERSION=$KERNEL_VERSION > $PRE_PATCH_DIR/$PRE_PATCH_INFO
+    rm -f $PRE_PATCH_FILE
+    cp $PATCH_FILE $PRE_PATCH_DIR/.
+    echo PRE_PATCH_FILE=$PRE_PATCH_DIR/$(basename $PATCH_FILE) >> $PRE_PATCH_DIR/$PRE_PATCH_INFO
+    if [ "$KERNEL_VERSION" != "$PRE_KERNEL_VERSION" ]; then
+      rm -rf linux-${PRE_KERNEL_VERSION}
+    fi
+  fi
+  return $RV
+}
+
+# Execution
+
+while getopts "hk:p:i:" opt; do
+  case "$opt" in
+    h) # display usage
+      usage
+      exit 0
+      ;;
+    k) # Specify kernel version
+      KERNEL_VERSION=$OPTARG
+      ;;
+    p) # Specify path to a patch file in kvms repository
+      PATCH_FILE=$OPTARG
+      ;;
+    i) # Specify path to Ubuntu VM Image
+      IMAGE_FILE=$OPTARG
+      ;;
+    d) # Specify directory to store kernel patch and version information file
+      PRE_PATCH_DIR=$OPTARG
+      ;;
+    f) # Specify a name for file to store kernel version and patch path
+      PRE_PATCH_INFO=$OPTARG
+      ;;
+   \?) # Invalid option
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! -f "$PRE_PATCH_DIR/$PRE_PATCH_INFO" ]; then
+  echo "No previous kernel information found. Patching kernel.."
+  update_kernel
+  exit $?
+fi
+
+. $PRE_PATCH_DIR/$PRE_PATCH_INFO
+
+if [ "$KERNEL_VERSION" != "$PRE_KERNEL_VERSION" ]; then
+  echo "New kernel version: $KERNEL_VERSION used. Patching kernel.."
+  update_kernel
+  exit $?
+fi
+
+echo "Comparing kernel patch to previous patch:"
+diff $PATCH_FILE $PRE_PATCH_FILE
+if [ "$?" -eq 0 ]; then
+  echo "Kernel patch has no changes. No need for patching kernel."
+  exit 0
+elif [ "$?" -eq 1 ]; then
+  echo "Kernel patch has been changed. Patching kernel.."
+  update_kernel
+  exit $?
+else
+  echo "diff returned $?."
+  echo "Kernel patch comparison failed."
+  echo "There is probably some environemnt related trouble."
+  exit $?
+fi

--- a/scripts/ci-check-kernel-patch.sh
+++ b/scripts/ci-check-kernel-patch.sh
@@ -30,6 +30,10 @@ usage() {
 }
 
 update_kernel() {
+  # always remove the source directories used to patch, build and update previous kernel versions first
+  # directories are created by running the update_kernel_to_ubuntu_VMs.sh script with the superuser privileges
+  sudo rm -rf linux-${KERNEL_VERSION} # previously patched kernel modules will not be re-used when only patch has changes
+  sudo rm -rf linux-${PRE_KERNEL_VERSION}
   sudo modprobe nbd max_part=8
   sudo scripts/update_kernel_to_ubuntu_VMs.sh -i $IMAGE_FILE -k $KERNEL_VERSION -p $PATCH_FILE
   RV=$?
@@ -40,9 +44,6 @@ update_kernel() {
     rm -f $PRE_PATCH_FILE
     cp $PATCH_FILE $PRE_PATCH_DIR/.
     echo PRE_PATCH_FILE=$PRE_PATCH_DIR/$(basename $PATCH_FILE) >> $PRE_PATCH_DIR/$PRE_PATCH_INFO
-    if [ "$KERNEL_VERSION" != "$PRE_KERNEL_VERSION" ]; then
-      rm -rf linux-${PRE_KERNEL_VERSION}
-    fi
   fi
   return $RV
 }

--- a/scripts/ci-check-kernel-patch.sh
+++ b/scripts/ci-check-kernel-patch.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -x
 
-# Script used to compare kernel version and patch used in previous CI build.
+# Script used to compare kernel version and patch to ones used in previous CI build
+#
 # If a new kernel version or patch is used in CI build, scripts/update_kernel_to_ubuntu_VMs.sh will be executed.
-# The script will also remove the previous directory where kernel was updated (linux-<kernel version>) from workspace,
-# if a new kernel version is used in the current CI build.
+# A previous directory where kernel was updated (linux-<kernel version>) will also be removed from workspace,
+# if a new kernel version was used in the build.
 
 # Variables
 
@@ -37,7 +38,7 @@ update_kernel() {
   sudo modprobe nbd max_part=8
   sudo scripts/update_kernel_to_ubuntu_VMs.sh -i $IMAGE_FILE -k $KERNEL_VERSION -p $PATCH_FILE
   RV=$?
-  # storing kernel version / patch information for next build
+  # storing kernel version, patch and info file for next build
   if [ "$RV" -eq 0 ]; then
     mkdir -p $PRE_PATCH_DIR
     echo PRE_KERNEL_VERSION=$KERNEL_VERSION > $PRE_PATCH_DIR/$PRE_PATCH_INFO
@@ -84,7 +85,10 @@ if [ ! -f "$PRE_PATCH_DIR/$PRE_PATCH_INFO" ]; then
   exit $?
 fi
 
-. $PRE_PATCH_DIR/$PRE_PATCH_INFO
+# assigning:
+# PRE_KERNEL_VERSION -- kernel version of previous build
+# PRE_PATCH_FILE     -- path to kernel patch stored in previous build
+source $PRE_PATCH_DIR/$PRE_PATCH_INFO
 
 if [ "$KERNEL_VERSION" != "$PRE_KERNEL_VERSION" ]; then
   echo "New kernel version: $KERNEL_VERSION used. Patching kernel.."

--- a/scripts/ci-check-kernel-patch.sh
+++ b/scripts/ci-check-kernel-patch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 
 # Script used to compare kernel version and patch used in previous CI build.
 # If a new kernel version or patch is used in CI build, scripts/update_kernel_to_ubuntu_VMs.sh will be executed.


### PR DESCRIPTION
Remove kernel source directories used in previous build to patch, build
and update kernel modules of the test VMs when either new kernel
version will be used or patch file have changes.

modified:   Jenkinsfile
- Environment directive added to Jenkinsfile for easier configuration
- Kernel versions of test VMs updated from to 5.10.108 to 5.10.130

new file:   scripts/ci-check-kernel-patch.sh
- Kernel is updated to test VMs only if kernel version or patch differs
from previous build
- This is workaround until builds will be using shared workspace.