### PR TITLE
scripts: add some missing packages and cleanup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y git-core gnupg flex bison build-essenti
 RUN apt-get install -y pip crossbuild-essential-arm64
 RUN apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu make ninja-build bsdmainutils libdrm-dev libegl-dev libegl1-mesa-dev libelf-dev libexpat1-dev libgl-dev libgles-dev libglib2.0-dev libglib2.0-dev-bin libglu1-mesa-dev libglvnd-core-dev libglx-dev libgmp-dev libice-dev libmagic-dev libmpc-dev libmpfr-dev libpcre3-dev libpcre2-dev libpixman-1-dev libpng-dev libpopt-dev libpulse-dev libsdl1.2-dev libsdl2-dev libspice-protocol-dev libspice-server-dev libwayland-dev libxau-dev libxinerama-dev libxrandr-dev linux-libc-dev xtrans-dev libstdc++-7-dev libssl-dev git texi2html texinfo rsync gawk bc python sudo wget qemu binfmt-support qemu-user-static libx11-xcb1 libx11-6 libxkbcommon0 libxkbcommon-x11-0 libvulkan-dev libvulkan1 libstdc++6-arm64-cross
 RUN apt-get install -y libepoxy0 libvirglrenderer1 meson python3-mako libxdamage-dev libxcb-glx0-dev libx11-xcb-dev libxcb-dri2-0-dev libxcb-dri3-dev libxcb-present-dev libxshmfence-dev llvm libvirglrenderer-dev libaio-dev libepoxy-dev wayland-protocols libwayland-egl-backend-dev
-RUN apt-get install -y net-tools iputils-ping iproute2 gdb-multiarch sshpass
+RUN apt-get install -y net-tools iputils-ping iproute2 gdb-multiarch sshpass device-tree-compiler
 RUN apt-get update && apt-get install -y doxygen graphviz texlive-latex-base texlive-fonts-recommended texlive-latex-extra
 
 RUN pip install absl-py && pip install urlfetch

--- a/scripts/build-target-qemu.sh
+++ b/scripts/build-target-qemu.sh
@@ -238,5 +238,5 @@ do_spice
 do_qemu
 [ -n "$ANDROID_EMU" ] && do_android_emulator
 [ -z "$STATIC" ] && do_hybris
-[ -n "$HOSTCVD"] do_host_cvd_package
+[ -n "$HOSTCVD" ] && do_host_cvd_package
 echo "All ok!"

--- a/scripts/package.list
+++ b/scripts/package.list
@@ -333,3 +333,15 @@ libmpc-dev
 libmpfr-dev
 libelf-dev
 libspice-server-dev
+devscripts
+config-package-dev
+debhelper-compat
+golang
+curl
+bridge-utils
+dnsmasq-base
+f2fs-tools
+iptables
+libarchive-tools
+libusb-1.0-0 net-tools
+qemu-user-static


### PR DESCRIPTION
Hi,

This pr adds device-tree-compiler package to docker image for fixing the virt device compilation issues. Also fixes target-qemu and adds some missing packages for ubuntu chroot.