### PR TITLE
makevars.mk: Fix _FORTIFY_SOURCE macro

### DIFF
--- a/core/makevars.mk
+++ b/core/makevars.mk
@@ -8,7 +8,7 @@
 ifdef DEBUG
 BUILDOPTS := -g3 -Os -DCRASHDUMP
 else
-BUILDOPTS := -g1 -Os -DFORTIFY_SOURCE=1 -Wl,-O2
+BUILDOPTS := -g1 -Os -D_FORTIFY_SOURCE=1 -Wl,-O2
 endif
 
 #


### PR DESCRIPTION
This commit fixes the mistake in the `_FORTIFY_SOURCE` macro where it was not 
prefixed with underscore while it has to be (see e.g. 
https://github.com/search?q=repo%3Abminor%2Fglibc%20FORTIFY_SOURCE&type=code).

Additionally, to make this macro add extra security, one has to enable optimizations.