### PR TITLE
scripts: target-qemu: report umount failure on /proc and /dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,13 @@ module-test:
 target-qemu:
 	./scripts/build-target-qemu.sh
 
+target-qemu-clean:
+	./scripts/build-target-qemu.sh clean
+
+target-qemu-distclean:
+	./scripts/build-target-qemu.sh distclean
+
+
 sign_guest: gen_key
 	@[ "${IMAGE}" ] && echo -n "" || ( echo "IMAGE is not set"; exit 1 )
 	$(BASE_DIR)/scripts/sign_guest_kernel.sh -p $(KEYS_PATH)/guest_image_priv.pem \


### PR DESCRIPTION
Rarely umount of /proc and /dev fails, but the cleanup just passes through without reporting the error. This may lead a user can do unwanted deletion of these mounted directories while they clean up the ubuntu directory. Or when users try to make a tar ball of ubuntu, /proc/kcore may be included and huge size of tar ball may be created.

This patch tries to check mount status and to report errors of umount to users, and additionally provides
'make target-qemu-clean' for cleanup of oss/ubuntu/build and 'make target-qemu-distclean' for cleanup of oss/ubuntu.

Change-Id: Ib3cfafc8eaec8c3e86c2816b379d1d2041b21359
Signed-off-by: Sahara <keun-o.park@digital14.com>