### PR TITLE
docker: add support to specify openssl version for docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,15 @@ RUN apt-get install -y kmod qemu-utils parted
 
 RUN pip install absl-py && pip install urlfetch
 
+# Allow choosing a specific openssl version
+ARG OPENSSL
+RUN if [ -n "$OPENSSL" ] ; then cd /tmp \
+&& wget https://www.openssl.org/source/${OPENSSL}.tar.gz \
+&& tar -xvf ${OPENSSL}.tar.gz \
+&& cd /tmp/${OPENSSL} && ./config shared -Wl,-rpath=/usr/local/ssl/lib --prefix=/usr/local/ssl \
+&& make -j 4 && make install \
+&& mv /usr/bin/openssl /usr/bin/openssl.old && ln -s /usr/local/ssl/bin/openssl /usr/bin/openssl; fi
+
 RUN groupadd -g $groupid $username \
  && useradd -m -u $userid -g $groupid $username \
  && echo $username >/root/username

--- a/docker/README.md
+++ b/docker/README.md
@@ -90,3 +90,11 @@ Sometimes when running on arm64 hardware it is convenient to use static qemu-sys
 ```
 STATIC=1 make target-qemu
 ```
+
+Ubuntu 22 environment is using OpenSSL version 3.0+ which can break some of the tooling that depends
+on the older versions. In that case you can specify an additional argument to the docker build script,
+e.g. for using `openssl-1.1.1t`
+
+```
+--build-arg OPENSSL=openssl-1.1.1t
+```


### PR DESCRIPTION
Ubuntu 22 environment is using OpenSSL version 3.0+ which can break some of the tooling that depends
on older versions. This allows us to specify additional argument (e.g. --build-arg OPENSSL=openssl-1.1.1t) to the build script for using a different version.

Signed-off-by: Sohaib ul Hassan <sohaib.ul.hassan@unikie.com>