### PR TITLE
Build fixes and improvement

### DIFF
--- a/core/imager/Makefile
+++ b/core/imager/Makefile
@@ -4,6 +4,15 @@ OUTDIR := $(OBJDIR)/$(PLATFORM)
 else
 OUTDIR := $(OBJDIR)/$(PLATFORM)/$(CHIPSET)/$(PRODUCT)
 endif
+
+ifneq (,$(wildcard $(BASE_DIR)/platform/$(PLATFORM)/common))
+COMMON_DIR := /common
+endif
+PROG := $(shell cat '$(BASE_DIR)/platform/$(PLATFORM)$(COMMON_DIR)/Makefile' \
+        | sed -ne 's/^PROG := //p' | sed 's/.*\///')
+
+$(info Creating compressed image for : $(PROG).bin )
+
 export OUTDIR := $(OUTDIR)
 PHONY := all clean
 
@@ -28,7 +37,7 @@ $(OUTDIR)/comptool: $(OUTDIR)/lz4
 	@$(CC) -o $@ comptool.c $(LZ4DIR)/lib/lz4.c $(LZ4DIR)/lib/lz4hc.c $(CTOOL_CFLAGS)
 
 $(OUTDIR)/hyp-binary.o: $(OUTDIR)/comptool
-	@$< $(OUTDIR)/$(PROG)*.bin $@.lz4
+	@$< $(OUTDIR)/$(PROG).bin $@.lz4
 	@$(CROSS_COMPILE)ld -r -b binary -o $@ $@.lz4
 
 $(OUTDIR)/lreset.o:

--- a/core/tools.mk
+++ b/core/tools.mk
@@ -17,3 +17,4 @@ export TOOLS_QEMU := $(TOOLDIR)/usr/bin/qemu-system-aarch64
 export FETCH_SOURCES := oss/gcc/configure
 export SED := sed
 export DOXYGEN := doxygen
+export BUILD_TOOLS := $(TOOLDIR)/usr/bin/aarch64-linux-gnu-gcc

--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -34,6 +34,8 @@ TTRIPLET="aarch64-linux-gnu"
 HTRIPLET="x86_64-unknown-linux-gnu"
 NJOBS=`nproc`
 
+[ $PLATFORM == "virt" ] && VIRTOOLS=1
+
 clean()
 {
 	cd $BASE_DIR/oss/binutils-gdb; git clean -xfd || true
@@ -131,6 +133,8 @@ binutils-gdb
 kernel_headers
 glibc
 gcc
+if [ -n "$VIRTOOLS" ]; then
 mesa
 qemu
 kernel
+fi


### PR DESCRIPTION
Hi,

This series of patches adds support to build qemu, linux kernel and mesa only for virt platform.

Also fixes a compilation error in comptool when recompiling without a clean build.