### PR TITLE
core: add trace info for host instruction abort

### DIFF
--- a/core/guest.h
+++ b/core/guest.h
@@ -443,6 +443,18 @@ bool host_data_abort(uint64_t vmid, uint64_t ttbr0_el1, uint64_t far_el2,
 		     void *regs);
 
 /*
+ * Process host instruction abort
+ *
+ * @param vmid, the host vmid
+ * @param uint64_t ttbr0_el1
+ * @param uint64_t far_el2
+ * @param regs array of the given exception registers
+ * @return true if the abort was correctly handled
+ */
+void host_inst_abort(uint64_t vmid, uint64_t ttbr0_el1, uint64_t far_el2,
+		     void *regs);
+
+/*
  * Crash guest qemu process on access violation
  *
  * @param guest the guest

--- a/core/ventry.S
+++ b/core/ventry.S
@@ -234,7 +234,13 @@ instruction_abort:
 	b	guest_instruction_abort
 
 host_instruction_abort:
-	b	host_fastforward
+	save_all_regs
+	mrs	x1, TTBR0_EL1
+	mrs	x2, FAR_EL2
+	mov	x3, sp
+	bl	host_inst_abort
+	load_all_regs
+	b	forward_aarch64sync
 
 guest_instruction_abort:
 	save_all_regs


### PR DESCRIPTION
Hi,

This patch adds debug information to the exception vector for host instruction abort instead of just silent fast forward.