### PR TITLE
core: add initial support for memory tagging extension

### DIFF
--- a/core/bits.h
+++ b/core/bits.h
@@ -38,6 +38,10 @@
 #define HCR_NV1_BIT 43
 #define HCR_NV2_BIT 45
 
+#define HCR_ATA_BIT 56
+#define HCR_DCT_BIT 57
+#define HCR_TID5_BIT 58
+
 /* CPTR */
 #define CPTR_TCPAC_BIT 31
 #define CPTR_TTA_BIT 28

--- a/core/hvccall.c
+++ b/core/hvccall.c
@@ -651,6 +651,28 @@ void memctrl_exec(uint64_t *sp)
 		write_reg(APDBKEYHI_EL1, sp[rt]);
 		break;
 #endif
+#if MEMTAG
+	case 0x30140C:
+		PRINTREG("vmid %u core %u tfsr_el1 0x%lx\n", vmid, cid, sp[rt]);
+		write_reg(TFSR_EL1, sp[rt]);
+		break;
+	case 0x32140C:
+		PRINTREG("vmid %u core %u tfsre0_el1 0x%lx\n", vmid, cid, sp[rt]);
+		write_reg(TFSRE0_EL1, sp[rt]);
+		break;
+	case 0x384000:
+		PRINTREG("vmid %u core %u gmid_el1 0x%lx\n", vmid, cid, sp[rt]);
+		write_reg(GMID_EL1, sp[rt]);
+		break;
+	case 0x3A0400:
+		PRINTREG("vmid %u core %u rgsr_el1 0x%lx\n", vmid, cid, sp[rt]);
+		write_reg(RGSR_EL1, sp[rt]);
+		break;
+	case 0x3C0400:
+		PRINTREG("vmid %u core %u gcr_el1 0x%lx\n", vmid, cid, sp[rt]);
+		write_reg(GCR_EL1, sp[rt]);
+		break;
+#endif
 	case 0x320800:
 		PRINTREG("vmid %u core %u ttbr1_el1 0x%lx\n", vmid, cid, sp[rt]);
 		write_reg(TTBR1_EL1, sp[rt]);

--- a/core/makeflags.mk
+++ b/core/makeflags.mk
@@ -45,6 +45,10 @@ else
 export ARM_BASE=armv8-a
 endif
 
+ifeq ($(MEMTAG),1)
+export ARM_BASE=armv8.5-a
+endif
+
 export CFLAGS := \
 	--sysroot=$(TOOLDIR) --no-sysroot-suffix -fstack-protector-strong -mstrict-align \
 	-static -ffreestanding -fno-hosted -std=c99 -fno-omit-frame-pointer -fno-data-sections \
@@ -59,7 +63,15 @@ endif
 export CFLAGS += -march=$(ARM_BASE)+nosimd -mgeneral-regs-only
 
 ifeq ($(PTRAUTH),1)
-export CFLAGS += -mbranch-protection=standard -DPTRAUTH
+export CFLAGS += -DPTRAUTH
+endif
+
+ifeq ($(MEMTAG),1)
+export CFLAGS += -march=$(ARM_BASE)+memtag
+endif
+
+ifneq (,$(filter 1,$(PTRAUTH) $(MEMTAG)))
+export CFLAGS += -mbranch-protection=standard
 endif
 
 export ASFLAGS := -D__ASSEMBLY__ $(CFLAGS)

--- a/core/makevars.mk
+++ b/core/makevars.mk
@@ -58,6 +58,14 @@ else
 endif
 
 #
+# Define if system should support memory tagging extension.
+#
+ifeq ($(MEMTAG),1)
+BUILDOPTS += -DMEMTAG
+else
+endif
+
+#
 # Add validate.c tests into the build. These symbols are for
 # hypervisor internal state validation and can be called via
 # the debugger.

--- a/platform/common/platform_api.c
+++ b/platform/common/platform_api.c
@@ -48,6 +48,15 @@ void platform_early_setup(void)
 	bit_set(hcr_el2, HCR_TVM_BIT);
 	//bit_set(hcr_el2, HCR_APK_BIT);
 	bit_set(hcr_el2, HCR_API_BIT);
+#ifndef MEMTAG
+	/*
+	 * this will have no effect if platform
+	 * doesn't support MTE, here just for info
+	 */
+	bit_set(hcr_el2, HCR_ATA_BIT);
+
+#endif
+	/* TODO: HCR_DCT_BIT */
 	write_reg(HCR_EL2, hcr_el2);
 
 	/* EL1 timer access */

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -39,8 +39,13 @@ else
 HYP_IMAGE := -device loader,file=$(PROG).bin,addr=0xC0000000,force-raw=true
 endif
 
+MTE := off
+ifeq ($(MEMTAG),1)
+override MTE := on
+endif
+
 QEMUOPTS := --accel tcg,thread=multi -d $(QEMUDEBUGOPTS) $(QEMUDEBUGLOG) $(DEBUGOPTS) \
-	    -machine virt,virtualization=on,secure=off,gic-version=3 \
+	    -machine virt,virtualization=on,secure=off,gic-version=3,mte=$(MTE)\
 	    -cpu max,sve=off,lpa2=off -smp 4 -m 8G $(NETWORK) $(USB) $(BOOTIMG) \
 	    -kernel $(KERNEL) -append '$(KERNEL_OPTS)' -dtb $(DTB) $(HYP_IMAGE)
 

--- a/platform/virt/host_platform.h
+++ b/platform/virt/host_platform.h
@@ -32,7 +32,11 @@
 #define PLAT_NORMAL_WBACK_P 4
 #define PLAT_NORMAL_WT_P 5
 
+#ifdef MEMTAG
+#define PLATFORM_MAIR_EL2 0x00f0bbff440c0400
+#else
 #define PLATFORM_MAIR_EL2 0x0000bbff440c0400
+#endif
 
 int console_putc(unsigned char);
 


### PR DESCRIPTION
Hi,

This introduces mte sys registers and some basic support to allow the system to boot with mte feature enabled.

For virt enviroment `MEMTAG=1 make run` will enable mte for tcg emulation.

After:

[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: detected: Memory Tagging Extension
[    0.000000] CPU features: detected: Spectre-v4